### PR TITLE
Fix/pdf scraping strategy

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -442,6 +442,12 @@ async def handle_crawl_request(
         
         is_pdf_flags = await asyncio.gather(*(is_pdf_url(url) for url in urls))
         is_pdf = any(is_pdf_flags)
+        if any(is_pdf_flags) and not all(is_pdf_flags):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Mix of PDF and non-PDF URLs in a single request is not supported yet."
+            )
+            
         crawler_strategy = PDFCrawlerStrategy() if is_pdf else None
 
         if is_pdf and crawler_config.scraping_strategy is None:
@@ -546,6 +552,12 @@ async def handle_stream_crawl_request(
         
         is_pdf_flags = await asyncio.gather(*(is_pdf_url(url) for url in urls))
         is_pdf = any(is_pdf_flags)
+        if any(is_pdf_flags) and not all(is_pdf_flags):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Mix of PDF and non-PDF URLs in a single request is not supported yet."
+            )
+            
         crawler_strategy = PDFCrawlerStrategy() if is_pdf else None
 
         if is_pdf and crawler_config.scraping_strategy is None:

--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -445,7 +445,7 @@ async def handle_crawl_request(
         crawler_strategy = PDFCrawlerStrategy() if is_pdf else None
 
         if is_pdf and crawler_config.scraping_strategy is None:
-            # Default strategy if not set
+            # Default strategy if not set.
             crawler_config.scraping_strategy = PDFContentScrapingStrategy(
                 extract_images=False,
                 save_images_locally=False,

--- a/deploy/docker/crawler_pool.py
+++ b/deploy/docker/crawler_pool.py
@@ -31,6 +31,7 @@ def _sig(cfg: BrowserConfig, crawler_strategy: Optional[object]  = None) -> str:
 
 
 async def get_crawler(cfg: BrowserConfig, crawler_strategy: Optional[object] = None) -> AsyncWebCrawler:
+    sig: Optional[str] = None
     try:
         sig = _sig(cfg, crawler_strategy=crawler_strategy)
         async with LOCK:
@@ -48,12 +49,13 @@ async def get_crawler(cfg: BrowserConfig, crawler_strategy: Optional[object] = N
     except Exception as e:
         raise RuntimeError(f"Failed to start browser: {e}")
     finally:
-        if sig in POOL:
+        if sig and sig in POOL:
             LAST_USED[sig] = time.time()
         else:
             # If we failed to start the browser, we should remove it from the pool
-            POOL.pop(sig, None)
-            LAST_USED.pop(sig, None)
+            if sig:
+                POOL.pop(sig, None)
+                LAST_USED.pop(sig, None)
         # If we failed to start the browser, we should remove it from the pool
         
 async def close_all():

--- a/deploy/docker/crawler_pool.py
+++ b/deploy/docker/crawler_pool.py
@@ -49,14 +49,13 @@ async def get_crawler(cfg: BrowserConfig, crawler_strategy: Optional[object] = N
     except Exception as e:
         raise RuntimeError(f"Failed to start browser: {e}")
     finally:
-        if sig and sig in POOL:
-            LAST_USED[sig] = time.time()
-        else:
-            # If we failed to start the browser, we should remove it from the pool
-            if sig:
-                POOL.pop(sig, None)
-                LAST_USED.pop(sig, None)
-        # If we failed to start the browser, we should remove it from the pool
+        async with LOCK:
+            if sig and sig in POOL:
+                LAST_USED[sig] = time.time()
+            else:
+                if sig:
+                    POOL.pop(sig, None)
+                    LAST_USED.pop(sig, None)
         
 async def close_all():
     async with LOCK:

--- a/deploy/docker/utils.py
+++ b/deploy/docker/utils.py
@@ -137,7 +137,7 @@ async def is_pdf_url(url: str) -> bool:
     if url.lower().endswith(".pdf"):
         return True
 
-    timeout = httpx.Timeout(connect=5.0, read=10.0, write=5.0)
+    timeout = httpx.Timeout(5.0)
     async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
         # HEAD request to check Content-Type (ignore servers that reject HEAD)
         try:

--- a/deploy/docker/utils.py
+++ b/deploy/docker/utils.py
@@ -137,20 +137,22 @@ async def is_pdf_url(url: str) -> bool:
     if url.lower().endswith(".pdf"):
         return True
 
-    try:
-        async with httpx.AsyncClient(follow_redirects=True) as client:
-            # HEAD request to check Content-Type
-            head_resp = await client.head(url)
+    timeout = httpx.Timeout(connect=5.0, read=10.0, write=5.0)
+    async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
+        # HEAD request to check Content-Type (ignore servers that reject HEAD)
+        try:
+            head_resp = await client.head(url, headers={"Accept": "*/*"})
             content_type = head_resp.headers.get("content-type", "").lower()
             if "application/pdf" in content_type:
                 return True
+        except httpx.HTTPError:
+            pass
 
-            # Fallback: GET first 5 bytes to check PDF magic number
+        # Fallback: GET first 5 bytes to check PDF magic number
+        try:
             get_resp = await client.get(url, headers={"Range": "bytes=0-4"})
             if get_resp.status_code in (200, 206):  # 206 Partial Content
                 return get_resp.content.startswith(b"%PDF-")
-    except Exception:
-        return False
-
-    return False
+        except httpx.HTTPError:
+            return False
 

--- a/docs/examples/docker/demo_docker_api.py
+++ b/docs/examples/docker/demo_docker_api.py
@@ -18,10 +18,8 @@ load_dotenv()  # Load environment variables from .env file
 console = Console()
 
 # --- Configuration ---
-BASE_URL = os.getenv("CRAWL4AI_TEST_URL", "http://localhost:8020")
 BASE_URL = os.getenv("CRAWL4AI_TEST_URL", "http://localhost:11235")
 # Target URLs
-SIMPLE_URL = "https://example.com"  # For demo purposes
 SIMPLE_URL = "https://httpbin.org/html"
 LINKS_URL = "https://httpbin.org/links/10/0"
 FORMS_URL = "https://httpbin.org/forms/post"  # For JS demo

--- a/docs/examples/docker/demo_docker_api.py
+++ b/docs/examples/docker/demo_docker_api.py
@@ -25,7 +25,7 @@ LINKS_URL = "https://httpbin.org/links/10/0"
 FORMS_URL = "https://httpbin.org/forms/post"  # For JS demo
 BOOKS_URL = "http://books.toscrape.com/"  # For CSS extraction
 PYTHON_URL = "https://python.org"  # For deeper crawl
-PDF_URL = "https://arxiv.org/pdf/2310.06825.pdf" # For PDF demo
+PDF_URL = "https://arxiv.org/pdf/2310.06825" # For PDF demo
 # Use the same sample site as deep crawl tests for consistency
 DEEP_CRAWL_BASE_URL = os.getenv(
     "DEEP_CRAWL_TEST_SITE", "https://docs.crawl4ai.com/samples/deepcrawl/")
@@ -1290,12 +1290,9 @@ async def demo_pdf_crawl(client: httpx.AsyncClient):
     print("Number of results:", len(data.get("results", [])))
     if data.get("results"):
         first = data["results"][0]
-        text = first.get("extracted_content") or first.get("text") or ""
-        if isinstance(text, dict):
-            text = text.get("text") or ""
+        text_snippet = (first.get("text") or "")[:500]
         print("Extracted text (first 500 chars):")
-        print((text or "")[:500])
-
+        print(text_snippet)
         
 # 11. Crawl PDF stream
 
@@ -1311,7 +1308,7 @@ async def demo_pdf_crawl_stream(client: httpx.AsyncClient):
             "params": {
                 "stream": True,
                 "cache_mode": "BYPASS",
-                "scraping_strategy": {
+                "scraping_strategy": {  # <-- Default strategy if not set
                     "type": "PDFContentScrapingStrategy",
                     "params": {
                         "extract_images": False,     

--- a/docs/examples/docker/demo_docker_api.py
+++ b/docs/examples/docker/demo_docker_api.py
@@ -25,7 +25,7 @@ LINKS_URL = "https://httpbin.org/links/10/0"
 FORMS_URL = "https://httpbin.org/forms/post"  # For JS demo
 BOOKS_URL = "http://books.toscrape.com/"  # For CSS extraction
 PYTHON_URL = "https://python.org"  # For deeper crawl
-PDF_URL = "https://arxiv.org/pdf/2310.06825" # For PDF demo
+PDF_URL = "https://arxiv.org/pdf/2310.06825.pdf" # For PDF demo
 # Use the same sample site as deep crawl tests for consistency
 DEEP_CRAWL_BASE_URL = os.getenv(
     "DEEP_CRAWL_TEST_SITE", "https://docs.crawl4ai.com/samples/deepcrawl/")
@@ -1289,9 +1289,12 @@ async def demo_pdf_crawl(client: httpx.AsyncClient):
     print("Number of results:", len(data.get("results", [])))
     if data.get("results"):
         first = data["results"][0]
-        text_snippet = (first.get("text") or "")[:500]
+        text = first.get("extracted_content") or first.get("text") or ""
+        if isinstance(text, dict):
+            text = text.get("text") or ""
         print("Extracted text (first 500 chars):")
-        print(text_snippet)
+        print((text or "")[:500])
+
         
 # 11. Crawl PDF stream
 
@@ -1306,7 +1309,7 @@ async def demo_pdf_crawl_stream(client: httpx.AsyncClient):
             "params": {
                 "stream": True,
                 "cache_mode": "BYPASS",
-                "scraping_strategy": {  # <-- Default strategy if not set
+                "scraping_strategy": {
                     "type": "PDFContentScrapingStrategy",
                     "params": {
                         "extract_images": False,     

--- a/docs/examples/docker/demo_docker_api.py
+++ b/docs/examples/docker/demo_docker_api.py
@@ -1265,6 +1265,7 @@ async def demo_config_dump_invalid(client: httpx.AsyncClient):
 async def demo_pdf_crawl(client: httpx.AsyncClient):
     payload = {
         "urls": [PDF_URL],
+        "browser_config": {"type": "BrowserConfig", "params": {"headless": True}},
         "crawler_config": {
             "type": "CrawlerRunConfig",
             "params": {
@@ -1304,6 +1305,7 @@ async def demo_pdf_crawl_stream(client: httpx.AsyncClient):
     """
     payload = {
         "urls": [PDF_URL],
+        "browser_config": {"type": "BrowserConfig", "params": {"headless": True}},
         "crawler_config": {
             "type": "CrawlerRunConfig",
             "params": {

--- a/tests/docker/test_rest_api_pdf_crawl.py
+++ b/tests/docker/test_rest_api_pdf_crawl.py
@@ -1,4 +1,4 @@
-# ==== File: test_rest_api_deep_crawl.py ====
+# ==== File: test_rest_api_pdf_crawl.py ====
 
 import pytest
 import pytest_asyncio
@@ -151,7 +151,7 @@ class TestPdfScraping:
         assert result["success"] is True
         assert "extracted_content" in result
         assert result["extracted_content"] is not None
-        # Vérifier que le texte extrait est non vide
+
         extracted_text = result["extracted_content"].get("text", "")
         assert isinstance(extracted_text, str)
         assert len(extracted_text) > 0
@@ -167,7 +167,7 @@ class TestPdfScraping:
                     "cache_mode": "BYPASS",
                     "scraping_strategy": {
                         "type": "PdfScrapingStrategy",
-                        "params": {"extract_metadata": True}  # Param spécifique pour métadonnées
+                        "params": {"extract_metadata": True}
                     },
                     "deep_crawl_strategy": {
                         "type": "BFSDeepCrawlStrategy",
@@ -186,13 +186,13 @@ class TestPdfScraping:
         assert "extracted_content" in result
         metadata = result["extracted_content"].get("metadata", {})
         assert isinstance(metadata, dict)
-        # Vérification simple : titre et auteur peuvent exister
+
         assert "title" in metadata or "author" in metadata
 
     async def test_pdf_scraping_non_accessible(self, async_client: httpx.AsyncClient):
         """Test PDF scraping when PDF is not accessible."""
         payload = {
-            "urls": [PDF_TEST_INVALID_URL],  # URL invalide
+            "urls": [PDF_TEST_INVALID_URL],
             "crawler_config": {
                 "type": "CrawlerRunConfig",
                 "params": {
@@ -211,7 +211,7 @@ class TestPdfScraping:
         }
 
         response = await async_client.post("/crawl", json=payload)
-        # Le serveur doit répondre OK mais le résultat doit indiquer échec
+
         data = response.json()
         assert data["success"] is True
         result = data["results"][0]

--- a/tests/docker/test_rest_api_pdf_crawl.py
+++ b/tests/docker/test_rest_api_pdf_crawl.py
@@ -1,0 +1,229 @@
+# ==== File: test_rest_api_deep_crawl.py ====
+
+import pytest
+import pytest_asyncio
+import httpx
+import json
+import asyncio
+import os
+from typing import List, Dict, Any, AsyncGenerator
+
+from dotenv import load_dotenv
+load_dotenv() # Load environment variables from .env file if present
+
+# --- Test Configuration ---
+BASE_URL = os.getenv("CRAWL4AI_TEST_URL", "http://localhost:11235") # If server is running in Docker, use the host's IP
+BASE_URL = os.getenv("CRAWL4AI_TEST_URL", "http://localhost:8020") # If server is running in dev debug mode
+PDF_TEST_URL = "https://arxiv.org/pdf/2310.06825"
+PDF_TEST_INVALID_URL = "https://docs.crawl4ai.com/samples/deepcrawl/"
+
+# --- Helper Functions ---
+def load_proxies_from_env() -> List[Dict]:
+    """Load proxies from PROXIES environment variable"""
+    proxies = []
+    proxies_str = os.getenv("PROXIES", "")
+    if not proxies_str:
+        print("PROXIES environment variable not set or empty.")
+        return proxies
+    try:
+        proxy_list = proxies_str.split(",")
+        for proxy in proxy_list:
+            proxy = proxy.strip()
+            if not proxy:
+                continue
+            parts = proxy.split(":")
+            if len(parts) == 4:
+                ip, port, username, password = parts
+                proxies.append({
+                    "server": f"http://{ip}:{port}", # Assuming http, adjust if needed
+                    "username": username,
+                    "password": password,
+                    "ip": ip  # Store original IP if available
+                })
+            elif len(parts) == 2: # ip:port only
+                 ip, port = parts
+                 proxies.append({
+                    "server": f"http://{ip}:{port}",
+                    "ip": ip
+                 })
+            else:
+                 print(f"Skipping invalid proxy string format: {proxy}")
+
+    except Exception as e:
+        print(f"Error loading proxies from environment: {e}")
+    return proxies
+
+
+async def check_server_health(client: httpx.AsyncClient):
+    """Check if the server is healthy before running tests."""
+    try:
+        response = await client.get("/health")
+        response.raise_for_status()
+        print(f"\nServer healthy: {response.json()}")
+        return True
+    except (httpx.RequestError, httpx.HTTPStatusError) as e:
+        pytest.fail(f"Server health check failed: {e}. Is the server running at {BASE_URL}?", pytrace=False)
+
+async def assert_crawl_result_structure(result: Dict[str, Any], check_ssl=False):
+    """Asserts the basic structure of a single crawl result."""
+    assert isinstance(result, dict)
+    assert "url" in result
+    assert "success" in result
+    assert "html" in result # Basic crawls should return HTML
+    assert "metadata" in result
+    assert isinstance(result["metadata"], dict)
+    assert "depth" in result["metadata"] # Deep crawls add depth
+
+    if check_ssl:
+        assert "ssl_certificate" in result # Check if SSL info is present
+        assert isinstance(result["ssl_certificate"], dict) or result["ssl_certificate"] is None
+
+
+async def process_streaming_response(response: httpx.Response) -> List[Dict[str, Any]]:
+    """Processes an NDJSON streaming response."""
+    results = []
+    completed = False
+    async for line in response.aiter_lines():
+        if line:
+            try:
+                data = json.loads(line)
+                if data.get("status") == "completed":
+                    completed = True
+                    break # Stop processing after completion marker
+                elif data.get("url"): # Ensure it looks like a result object
+                    results.append(data)
+                else:
+                    print(f"Received non-result JSON line: {data}") # Log other status messages if needed
+            except json.JSONDecodeError:
+                pytest.fail(f"Failed to decode JSON line: {line}")
+    assert completed, "Streaming response did not end with a completion marker."
+    return results
+
+
+# --- Pytest Fixtures ---
+@pytest_asyncio.fixture(scope="function")
+async def async_client() -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Provides an async HTTP client"""
+    # Increased timeout for potentially longer deep crawls
+    async with httpx.AsyncClient(base_url=BASE_URL, timeout=300.0) as client:
+        yield client
+    # No explicit close needed with 'async with'
+
+# --- Test Class for PDF Scraping ---
+@pytest.mark.asyncio
+class TestPdfScraping:
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def check_health_before_tests(self, async_client: httpx.AsyncClient):
+        """Fixture to ensure server is healthy before each test in the class."""
+        await check_server_health(async_client)
+
+    async def test_pdf_scraping_basic(self, async_client: httpx.AsyncClient):
+        """Test basic PDF scraping for a single PDF URL."""
+        payload = {
+            "urls": [PDF_TEST_URL],  # URL of a test PDF
+            "crawler_config": {
+                "type": "CrawlerRunConfig",
+                "params": {
+                    "stream": False,
+                    "cache_mode": "BYPASS",
+                    "scraping_strategy": {
+                        "type": "PdfScrapingStrategy",  # Custom PDF scraping strategy
+                        "params": {}
+                    },
+                    "deep_crawl_strategy": {
+                        "type": "BFSDeepCrawlStrategy",
+                        "params": {"max_depth": 0, "max_pages": 1}
+                    }
+                }
+            }
+        }
+
+        response = await async_client.post("/crawl", json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+        assert data["success"] is True
+        assert len(data["results"]) == 1
+
+        result = data["results"][0]
+        await assert_crawl_result_structure(result)
+        assert result["success"] is True
+        assert "extracted_content" in result
+        assert result["extracted_content"] is not None
+        # Vérifier que le texte extrait est non vide
+        extracted_text = result["extracted_content"].get("text", "")
+        assert isinstance(extracted_text, str)
+        assert len(extracted_text) > 0
+
+    async def test_pdf_scraping_with_metadata(self, async_client: httpx.AsyncClient):
+        """Test PDF scraping with metadata extraction."""
+        payload = {
+            "urls": [PDF_TEST_URL],
+            "crawler_config": {
+                "type": "CrawlerRunConfig",
+                "params": {
+                    "stream": False,
+                    "cache_mode": "BYPASS",
+                    "scraping_strategy": {
+                        "type": "PdfScrapingStrategy",
+                        "params": {"extract_metadata": True}  # Param spécifique pour métadonnées
+                    },
+                    "deep_crawl_strategy": {
+                        "type": "BFSDeepCrawlStrategy",
+                        "params": {"max_depth": 0, "max_pages": 1}
+                    }
+                }
+            }
+        }
+
+        response = await async_client.post("/crawl", json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+        assert data["success"] is True
+        result = data["results"][0]
+        assert "extracted_content" in result
+        metadata = result["extracted_content"].get("metadata", {})
+        assert isinstance(metadata, dict)
+        # Vérification simple : titre et auteur peuvent exister
+        assert "title" in metadata or "author" in metadata
+
+    async def test_pdf_scraping_non_accessible(self, async_client: httpx.AsyncClient):
+        """Test PDF scraping when PDF is not accessible."""
+        payload = {
+            "urls": [PDF_TEST_INVALID_URL],  # URL invalide
+            "crawler_config": {
+                "type": "CrawlerRunConfig",
+                "params": {
+                    "stream": False,
+                    "cache_mode": "BYPASS",
+                    "scraping_strategy": {
+                        "type": "PdfScrapingStrategy",
+                        "params": {}
+                    },
+                    "deep_crawl_strategy": {
+                        "type": "BFSDeepCrawlStrategy",
+                        "params": {"max_depth": 0, "max_pages": 1}
+                    }
+                }
+            }
+        }
+
+        response = await async_client.post("/crawl", json=payload)
+        # Le serveur doit répondre OK mais le résultat doit indiquer échec
+        data = response.json()
+        assert data["success"] is True
+        result = data["results"][0]
+        assert result["success"] is False
+        assert "extracted_content" not in result or result["extracted_content"] is None
+
+
+# --- Main Execution Block (for running script directly) ---
+if __name__ == "__main__":
+    pytest_args = ["-v", "-s", __file__]
+    # Example: Run only proxy test
+    # pytest_args.append("-k test_deep_crawl_with_proxies")
+    print(f"Running pytest with args: {pytest_args}")
+    exit_code = pytest.main(pytest_args)
+    print(f"Pytest finished with exit code: {exit_code}")

--- a/tests/docker/test_rest_api_pdf_crawl.py
+++ b/tests/docker/test_rest_api_pdf_crawl.py
@@ -72,7 +72,7 @@ class TestPdfScraping:
                     "stream": False,
                     "cache_mode": "BYPASS",
                     "scraping_strategy": {
-                        "type": "PdfScrapingStrategy",  # Custom PDF scraping strategy
+                        "type": "PDFContentScrapingStrategy",  # Custom PDF scraping strategy
                         "params": {}
                     },
                     "deep_crawl_strategy": {
@@ -100,39 +100,6 @@ class TestPdfScraping:
         assert isinstance(extracted_text, str)
         assert len(extracted_text) > 0
 
-    async def test_pdf_scraping_with_metadata(self, async_client: httpx.AsyncClient):
-        """Test PDF scraping with metadata extraction."""
-        payload = {
-            "urls": [PDF_TEST_URL],
-            "crawler_config": {
-                "type": "CrawlerRunConfig",
-                "params": {
-                    "stream": False,
-                    "cache_mode": "BYPASS",
-                    "scraping_strategy": {
-                        "type": "PdfScrapingStrategy",
-                        "params": {"extract_metadata": True}
-                    },
-                    "deep_crawl_strategy": {
-                        "type": "BFSDeepCrawlStrategy",
-                        "params": {"max_depth": 0, "max_pages": 1}
-                    }
-                }
-            }
-        }
-
-        response = await async_client.post("/crawl", json=payload)
-        response.raise_for_status()
-        data = response.json()
-
-        assert data["success"] is True
-        result = data["results"][0]
-        assert "extracted_content" in result
-        metadata = result["extracted_content"].get("metadata", {})
-        assert isinstance(metadata, dict)
-
-        assert "title" in metadata or "author" in metadata
-
     async def test_pdf_scraping_non_accessible(self, async_client: httpx.AsyncClient):
         """Test PDF scraping when PDF is not accessible."""
         payload = {
@@ -143,7 +110,7 @@ class TestPdfScraping:
                     "stream": False,
                     "cache_mode": "BYPASS",
                     "scraping_strategy": {
-                        "type": "PdfScrapingStrategy",
+                        "type": "PDFContentScrapingStrategy",
                         "params": {}
                     },
                     "deep_crawl_strategy": {

--- a/tests/docker/test_rest_api_pdf_crawl.py
+++ b/tests/docker/test_rest_api_pdf_crawl.py
@@ -16,7 +16,7 @@ BASE_URL = os.getenv(
     "CRAWL4AI_TEST_URL",
     "http://localhost:11235",  # Docker default; override via env for dev/debug (e.g., 8020)
 )
-PDF_TEST_URL = "https://arxiv.org/pdf/2310.06825"
+PDF_TEST_URL = "https://arxiv.org/pdf/2310.06825.pdf"
 PDF_TEST_INVALID_URL = "https://docs.crawl4ai.com/samples/deepcrawl/"
 
 # --- Helper Functions ---
@@ -94,9 +94,9 @@ class TestPdfScraping:
         assert "extracted_content" in result
         assert result["extracted_content"] is not None
 
-        extracted_text = result["extracted_content"].get("text", "")
-        assert isinstance(extracted_text, str)
-        assert len(extracted_text) > 0
+        content = result.get("extracted_content")
+        extracted_text = content.get("text", "") if isinstance(content, dict) else (content or "")
+        assert isinstance(extracted_text, str) and len(extracted_text) > 0
 
     async def test_pdf_scraping_non_accessible(self, async_client: httpx.AsyncClient):
         """Test PDF scraping when PDF is not accessible."""

--- a/tests/docker/test_rest_api_pdf_crawl.py
+++ b/tests/docker/test_rest_api_pdf_crawl.py
@@ -12,8 +12,10 @@ from dotenv import load_dotenv
 load_dotenv() # Load environment variables from .env file if present
 
 # --- Test Configuration ---
-BASE_URL = os.getenv("CRAWL4AI_TEST_URL", "http://localhost:11235") # If server is running in Docker, use the host's IP
-BASE_URL = os.getenv("CRAWL4AI_TEST_URL", "http://localhost:8020") # If server is running in dev debug mode
+BASE_URL = os.getenv(
+    "CRAWL4AI_TEST_URL",
+    "http://localhost:11235",  # Docker default; override via env for dev/debug (e.g., 8020)
+)
 PDF_TEST_URL = "https://arxiv.org/pdf/2310.06825"
 PDF_TEST_INVALID_URL = "https://docs.crawl4ai.com/samples/deepcrawl/"
 

--- a/tests/docker/test_rest_api_pdf_crawl.py
+++ b/tests/docker/test_rest_api_pdf_crawl.py
@@ -75,10 +75,6 @@ class TestPdfScraping:
                         "type": "PDFContentScrapingStrategy",  # Custom PDF scraping strategy
                         "params": {}
                     },
-                    "deep_crawl_strategy": {
-                        "type": "BFSDeepCrawlStrategy",
-                        "params": {"max_depth": 0, "max_pages": 1}
-                    }
                 }
             }
         }
@@ -113,10 +109,6 @@ class TestPdfScraping:
                         "type": "PDFContentScrapingStrategy",
                         "params": {}
                     },
-                    "deep_crawl_strategy": {
-                        "type": "BFSDeepCrawlStrategy",
-                        "params": {"max_depth": 0, "max_pages": 1}
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
This PR updates the crawl request handling to correctly apply the PDFCrawlerStrategy and PDFContentScrapingStrategy only when the URLs point to PDF files. Previously, all URLs were treated as web pages by default, which caused PDFs to be misprocessed.

- Ensures that PDFContentScrapingStrategy is used for PDF URLs when no custom scraping strategy is provided.
- Leaves non-PDF URLs to be handled by the default LXMLWebScrapingStrategy.
- Updates both streaming and non-streaming crawl request handlers.

Fixes issues where PDFs were downloaded but not processed correctly, e.g., missing content extraction.

## List of files changed and why
- `api.py` – Modified handle_crawl_request and handle_stream_crawl_request to dynamically apply PDFCrawlerStrategy and PDFContentScrapingStrategy for PDF URLs.
- `__init__.py` - Export PDFCrawlerStrategy, PDFContentScrapingStrategy
- `crawler_pool.py` - Edit `_sig()` and `get_crawler` to handle `crawler_strategy`
- `demo_docker_api.py` - Added examples/demo to illustrate PDF crawling usage.
- `utils.py` - Added `is_pdf_url` to be able to update the strategies

## How Has This Been Tested?
- Tested crawling a PDF URL (https://arxiv.org/pdf/2310.06825) with and without a custom scraping strategy.
- Verified that the PDF content is correctly extracted and returned in the response.
- Non-PDF URLs continue to be processed with the standard web scraping strategy.
- Unit tests for serialization and PDF content handling were run locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes